### PR TITLE
Security Wave 1 Changes - Enabling MSI for Grafana

### DIFF
--- a/Utils/ResourceGraphHelper.cs
+++ b/Utils/ResourceGraphHelper.cs
@@ -23,6 +23,15 @@ namespace Observability.Utils
 
         public ResourceGraphHelper(IConfiguration config, ILogger log, string tenantId)
         {
+
+            string msftTenantId = config.GetValue<string>("msftTenantId");
+            
+            if (tenantId != null && tenantId == msftTenantId) {
+                client = new ArmClient(
+                new ManagedIdentityCredential(config.GetValue<string>("msiclientId")));
+                return;
+            }
+
             try{
                 log.LogInformation($"Creating Arm Client for {tenantId}");
                             

--- a/Utils/scripts/Terraform/grafana-datasource/main.tf
+++ b/Utils/scripts/Terraform/grafana-datasource/main.tf
@@ -30,7 +30,7 @@ locals {
 dashboard_templates = "${path.cwd}/../../dashboard_templates"
 addperm_1 = "chmod 755 ${path.cwd}/../../grafana-datasource.sh"
 addperm_2 = "chmod 755 ${path.cwd}/../../update_drilldown.sh"
-create_datasource = "${path.cwd}/../../grafana-datasource.sh ${var.prefix} ${var.cluster_url} ${var.tenant_id} ${var.sp_client_id} ${var.sp_client_secret} ${var.database_name} ${local.dashboard_templates}"
+create_datasource = "${path.cwd}/../../grafana-datasource.sh ${var.prefix} ${var.cluster_url} ${var.database_name} ${local.dashboard_templates}"
 update_drilldowns = "${path.cwd}/../../update_drilldown.sh ${var.prefix} ${local.dashboard_templates}"
 }
 

--- a/Utils/scripts/Terraform/grafana-datasource/variables.tf
+++ b/Utils/scripts/Terraform/grafana-datasource/variables.tf
@@ -33,27 +33,6 @@ variable "database_name" {
   sensitive = false
 }
 
-#export TF_VAR_sp_client_id=$(terraform output -raw sp_client_id)
-variable "sp_client_id" {
-  type      = string
-  nullable  = false
-  sensitive = false
-}
-
-#export TF_VAR_tenant_id=$(terraform output -raw tenant_id)
-variable "tenant_id" {
-  type      = string
-  nullable  = false
-  sensitive = false
-}
-
-#export TF_VAR_sp_client_secret=$(terraform output -raw sp_client_secret)
-variable "sp_client_secret" {
-  type      = string
-  nullable  = false
-  sensitive = true
-}
-
 #export TF_VAR_prefix=$(terraform output -raw prefix)
 variable "prefix" {
   type      = string

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -708,7 +708,7 @@ resource "azurerm_role_assignment" "msi_adxingestionapp_role" {
 }
 
 #assign grafana admin access to user
-resource "azurerm_role_assignment" "grafana" {
+resource "azurerm_role_assignment" "grafanauser" {
   scope                = azurerm_dashboard_grafana.this.id
   role_definition_name = "Grafana Admin"
   principal_id         = data.azurerm_client_config.current.object_id
@@ -716,7 +716,7 @@ resource "azurerm_role_assignment" "grafana" {
 }
 
 #assign grafana admin access to msi
-resource "azurerm_role_assignment" "grafana" {
+resource "azurerm_role_assignment" "grafanamsi" {
   scope                = azurerm_dashboard_grafana.this.id
   role_definition_name = "Grafana Admin"
   principal_id         = azurerm_user_assigned_identity.terraform.principal_id

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -617,7 +617,7 @@ resource "azurerm_kusto_cluster_principal_assignment" "this" {
   cluster_name        = azurerm_kusto_cluster.this.name
 
   tenant_id      = data.azurerm_client_config.current.tenant_id
-  principal_id   = azuread_service_principal.this.application_id#data.azurerm_client_config.current.client_id
+  principal_id   = azuread_service_principal.this.client_id#data.azurerm_client_config.current.client_id
   principal_type = "App"
   role           = "AllDatabasesAdmin"
   depends_on = [azurerm_resource_group.rg,azurerm_kusto_cluster.this]

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -98,10 +98,10 @@ resource "azuread_service_principal" "this" {
   owners                       = [data.azuread_client_config.current.object_id]
 }
 
-#create the secret for the service principal
+/* #create the secret for the service principal
 resource "azuread_service_principal_password" "this" {
   service_principal_id = azuread_service_principal.this.object_id
-}
+} */
 
 #create resource group to house resources
 resource "azurerm_resource_group" "rg" {
@@ -136,12 +136,12 @@ resource "azurerm_key_vault" "kv" {
 }
 
 
-resource "azurerm_key_vault_secret" "client_secret_secret" {
+/* resource "azurerm_key_vault_secret" "client_secret_secret" {
   name         = "tenant-${data.azurerm_client_config.current.tenant_id}"//azuread_service_principal.this.application_id//"ServicePrincipalClientSecret"
   value        = "{\"ClientId\":\"${azuread_service_principal.this.application_id}\",\"ClientSecret\":\"${azuread_service_principal_password.this.value}\"}"//"${azuread_service_principal.this.application_id}-${azuread_service_principal_password.this.value}"//service_principal_id
   key_vault_id = azurerm_key_vault.kv.id
   depends_on = [azuread_service_principal_password.this]
-}
+} */
 
 
 #create a storage account
@@ -717,19 +717,6 @@ output "sp_object_id" {
 
 output "cluster_url" {
   value                = azurerm_kusto_cluster.this.uri
-}
-
-output "sp_client_id" {
-  value                = azuread_service_principal.this.application_id#
-}
-
-output "sp_client_secret" {
-  value                = azuread_service_principal_password.this.value
-  sensitive            = true
-}
-
-output "tenant_id" {
-  value                = data.azuread_client_config.current.tenant_id
 }
 
 output "database_name" {

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -385,6 +385,7 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
     storagesas=data.azurerm_storage_account_sas.this.sas
     blobConnectionString=azurerm_storage_account.this.primary_connection_string
     MyTimeTrigger="0 */15 * * * *"
+    msftTenantId="TenantId"
     keyVaultName=azurerm_key_vault.kv.name
 	}
 }

--- a/Utils/scripts/grafana-datasource.sh
+++ b/Utils/scripts/grafana-datasource.sh
@@ -31,15 +31,15 @@ az grafana data-source create -n $prefix-grafana --definition '{
   "basicAuth": false,
   "isDefault": false,
   "jsonData": {
-    "clientId": "'"$clientId"'",
     "clusterUrl": "'"$cluster_Url"'",
     "dataConsistency": "strongconsistency",
     "defaultDatabase": "'"$dbName"'",
     "defaultEditorMode": "visual",
     "schemaMappings": [],
-    "tenantId": "'"$tenantId"'"
-    },
-  "secureJsonData": {"clientSecret": "'"$clientSecret"'"},
+    "azureCredentials": {
+      "authType": "msi"
+    }
+  },
   "readOnly": false
 }'
 

--- a/Utils/scripts/grafana-datasource.sh
+++ b/Utils/scripts/grafana-datasource.sh
@@ -2,11 +2,8 @@
 
 prefix=$1
 cluster_Url=$2
-tenantId=$3
-clientId=$4
-clientSecret=$5
-dbName=$6
-METRICS_FOLDER_PATH=$7
+dbName=$3
+METRICS_FOLDER_PATH=$4
 
 echo $prefix
 echo $cluster_Url

--- a/Utils/scripts/grafana-datasource.sh
+++ b/Utils/scripts/grafana-datasource.sh
@@ -7,9 +7,6 @@ METRICS_FOLDER_PATH=$4
 
 echo $prefix
 echo $cluster_Url
-echo $tenantId
-echo $clientId
-echo $clientSecret
 echo $dbName
 echo $METRICS_FOLDER_PATH
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Security Wave 1 Changes
* Removing SP password creation 
* Removing export of ClientID and ClientSecret
* Enabling access to Grafana with MSI instead of Client Secret

Testing in MSFT Tenant
* These changes allow us to deploy and test in the Microsoft tenant again (make sure to follow steps below to update msftTenantId so the MSI can read monitoring data)
* **Storage blob and service bus changes are in progress, so after testing please disable both access keys on the Storage Account and local auth on Service Bus (will cause the deployment to break)**

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Security Change
```

## How to Test
* Follow the steps in README
* Open app settings for both AdxIngest and TimerStart Function and edit the msftTenantId property by pasting the Microsoft Tenant Id: 72f988bf-86f1-41af-91ab-2d7cd011db47
* Navigate to the created app registration of this deployment and make sure to add Service Tree info to Branding and Properties and an additional owner to the registration
![image](https://github.com/microsoft/mcsa-observability/assets/55116602/5a1b4229-026d-4392-a673-b29a73dfa38e)
![image](https://github.com/microsoft/mcsa-observability/assets/55116602/d3501eb6-9a1a-45ca-b4b4-528f21e89d15)

* In Grafana, open the Menu and navigate to Home > Connections > Data Sources > Observability Metrics Data Source


## What to Check
Verify that the following are valid
* Ensure that the Authentication Method shows Managed Identity
* Click "Save & test" and verify the status message looks like the own shown below (showing unable to connect to Azure Resource Graph is ok, but should say Success connecting to Azure Data Explorer)
![image](https://github.com/microsoft/mcsa-observability/assets/55116602/8b73f8d4-5a83-4a88-9477-7a79155fb0a9)
* Check for data in Grafana


## Other Information
Replaced deprecated application_id field with client_id to remove warnings during deployment