### PR TITLE
Security Wave 1: fix disabling local auth issue on service bus for adx

### DIFF
--- a/AdxIngestFunctionApp/AdxIngestFunction.cs
+++ b/AdxIngestFunctionApp/AdxIngestFunction.cs
@@ -31,7 +31,7 @@ namespace Observability.AdxIngestFunctionApp
         }
 
         [FunctionName("AdxIngestFunction")]
-        public static async Task Run([ServiceBusTrigger("%queueName%", Connection = "ServiceBusConnection", IsSessionsEnabled = false)] String myQueueItem, ILogger log)
+        public static async Task Run([ServiceBusTrigger("%queueName%", IsSessionsEnabled = false)] String myQueueItem, ILogger log)
         {
             ClientSecretCredential spCredential;
 

--- a/AdxIngestFunctionApp/AdxIngestFunction.cs
+++ b/AdxIngestFunctionApp/AdxIngestFunction.cs
@@ -31,7 +31,7 @@ namespace Observability.AdxIngestFunctionApp
         }
 
         [FunctionName("AdxIngestFunction")]
-        public static async Task Run([ServiceBusTrigger("%queueName%", IsSessionsEnabled = false)] String myQueueItem, ILogger log)
+        public static async Task Run([ServiceBusTrigger("%queueName%", Connection = "ServiceBusConnection", IsSessionsEnabled = false)] String myQueueItem, ILogger log)
         {
             ClientSecretCredential spCredential;
 

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -517,7 +517,8 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
   app_settings = {
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.adxingestionapp.instrumentation_key
     ServiceBusMSIConnection=local.serviceBusMSIString
-    ServiceBusConnection=azurerm_servicebus_namespace.this.default_primary_connection_string
+    ServiceBusConnection__fullyQualifiedNamespace = "${azurerm_servicebus_namespace.this.name}.servicebus.windows.net"
+    ServiceBusConnection__clientId = azurerm_user_assigned_identity.terraform.client_id
     adxConnectionString=azurerm_kusto_cluster.this.uri
     metricsdbName=local.metricdb_name
     adxIngestionURI=azurerm_kusto_cluster.this.data_ingestion_uri

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -517,8 +517,8 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
   app_settings = {
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.adxingestionapp.instrumentation_key
     ServiceBusMSIConnection=local.serviceBusMSIString
-    ServiceBusConnection__fullyQualifiedNamespace = "${azurerm_servicebus_namespace.this.name}.servicebus.windows.net"
-    ServiceBusConnection__clientId = azurerm_user_assigned_identity.terraform.client_id
+    ServiceBusConnection__fullyQualifiedNamespace="${azurerm_servicebus_namespace.this.name}.servicebus.windows.net"
+    ServiceBusConnection__clientId=azurerm_user_assigned_identity.terraform.client_id
     adxConnectionString=azurerm_kusto_cluster.this.uri
     metricsdbName=local.metricdb_name
     adxIngestionURI=azurerm_kusto_cluster.this.data_ingestion_uri


### PR DESCRIPTION
## Purpose
* solved issue 1: enabled msi for adx function to access service bus instead of using connection string.
* solved issue 2: when disabling the local auth on service bus, no error is triggered
* action 1: removed connection string with SAS to authenticate with service bus from adx function
* action 2: added necessary connection credentials in ADX function's environment variable for user assigned msi to be recognized by sb and loaded

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* follow README
* in the end, don't forget navigating to the created app registration of this deployment and make sure to add Service Tree info to Branding and Properties and an additional owner to the registration

## What to Check
* verify data is showing in both adx and grafana
* verify the log stream of adx. When disabling local auth on sb, there is no error and it successfully ingest data