### PR TITLE
Security Wave 1: modified deployment script for disabling local auth issues 

### DIFF
--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -394,7 +394,6 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
 
   site_config {
     always_on = true
-    vnet_route_all_enabled = true
   }
 
   app_settings = {
@@ -420,6 +419,7 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
 resource "azurerm_app_service_virtual_network_swift_connection" "timerstartpipelineapp_vnet_integration" {
   app_service_id = azurerm_windows_function_app.timerstartpipelineapp.id
   subnet_id      = azurerm_subnet.default_subnet.id
+  depends_on=[azurerm_subnet.default_subnet, azurerm_windows_function_app.timerstartpipelineapp]
 }
 
 resource "null_resource" "dotnet_build_timerpipelineapp" {
@@ -532,7 +532,6 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
 
   site_config {
     always_on = true
-    vnet_route_all_enabled = true
   }
   
   app_settings = {
@@ -560,7 +559,8 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "adxingestionapp_vnet_integration" {
   app_service_id = azurerm_windows_function_app.adxingestionapp.id
-  subnet_id      = azurerm_subnet.main_subnet.id
+  subnet_id      = azurerm_subnet.default_subnet.id
+  depends_on=[azurerm_subnet.default_subnet, azurerm_windows_function_app.adxingestapp]
 }
 
 resource "null_resource" "dotnet_build_adxingestapp" {

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -330,7 +330,7 @@ resource "azurerm_storage_account_network_rules" "this" {
 # Update shared access key setting after applying network rules
 resource "null_resource" "update_shared_access_key" {
   provisioner "local-exec" {
-    command = "az storage account update --name ${azurerm_storage_account.this.name} --resource-group ${azurerm_storage_account.this.resource_group_name} --set enableHttpsTrafficOnly=true --set sharedAccessKeyEnabled=false"
+    command = "az storage account update --name ${azurerm_storage_account.this.name} --resource-group ${azurerm_storage_account.this.resource_group_name} --set sharedAccessKeyEnabled=false"
   }
   depends_on = [azurerm_storage_account_network_rules.this]
 }

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -395,17 +395,13 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
   site_config {
     always_on = true
     vnet_route_all_enabled = true
-
-    ip_restriction {
-      subnet_id = azurerm_subnet.default_subnet.id
-    }
   }
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME="dotnet"
     AzureWebJobsStorage__accountName=local.storage_account_name
     AzureWebJobsStorage__clientId=azurerm_user_assigned_identity.terraform.client_id
-    AzureWebJobsStorage__credential=managedidentity
+    AzureWebJobsStorage__credential="managedidentity"
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.timerstartpipelineapp.instrumentation_key
     serviceBusNameSpace=azurerm_servicebus_namespace.this.name
     adxConnectionString=azurerm_kusto_cluster.this.uri
@@ -419,6 +415,11 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
     msftTenantId="TenantId"
     keyVaultName=azurerm_key_vault.kv.name
 	}
+}
+
+resource "azurerm_app_service_virtual_network_swift_connection" "timerstartpipelineapp_vnet_integration" {
+  app_service_id = azurerm_windows_function_app.timerstartpipelineapp.id
+  subnet_id      = azurerm_subnet.default_subnet.id
 }
 
 resource "null_resource" "dotnet_build_timerpipelineapp" {
@@ -532,17 +533,13 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
   site_config {
     always_on = true
     vnet_route_all_enabled = true
-
-    ip_restriction {
-      subnet_id = azurerm_subnet.default_subnet.id
-    }
   }
   
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME = "dotnet"
     AzureWebJobsStorage__accountName=local.storage_account_name
     AzureWebJobsStorage__clientId=azurerm_user_assigned_identity.terraform.client_id
-    AzureWebJobsStorage__credential=managedidentity
+    AzureWebJobsStorage__credential="managedidentity"
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.adxingestionapp.instrumentation_key
     ServiceBusConnection__fullyQualifiedNamespace="${azurerm_servicebus_namespace.this.name}.servicebus.windows.net"
     ServiceBusConnection__clientId=azurerm_user_assigned_identity.terraform.client_id
@@ -559,6 +556,11 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
     DefaultRequestHeaders="observabilitydashboard"
 	}
 
+}
+
+resource "azurerm_app_service_virtual_network_swift_connection" "adxingestionapp_vnet_integration" {
+  app_service_id = azurerm_windows_function_app.adxingestionapp.id
+  subnet_id      = azurerm_subnet.main_subnet.id
 }
 
 resource "null_resource" "dotnet_build_adxingestapp" {

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -560,7 +560,7 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
 resource "azurerm_app_service_virtual_network_swift_connection" "adxingestionapp_vnet_integration" {
   app_service_id = azurerm_windows_function_app.adxingestionapp.id
   subnet_id      = azurerm_subnet.default_subnet.id
-  depends_on=[azurerm_subnet.default_subnet, azurerm_windows_function_app.adxingestapp]
+  depends_on=[azurerm_subnet.default_subnet, azurerm_windows_function_app.adxingestionapp]
 }
 
 resource "null_resource" "dotnet_build_adxingestapp" {

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -324,7 +324,7 @@ resource "azurerm_storage_account_network_rules" "this" {
   default_action     = "Deny"
   virtual_network_subnet_ids = [azurerm_subnet.default_subnet.id]
   bypass                     = ["AzureServices"]
-  depends_on = [azurerm_storage_blob.this]  # Ensure network rules are applied after the blob is created
+  depends_on = [azurerm_storage_blob.this, azurerm_kusto_script.table]  # Ensure network rules are applied after the blob and kusto table are created
 }
 
 # Update shared access key setting after applying network rules

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -387,7 +387,6 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
   }
 
   site_config {
-    net_framework_version = "v6.0"
   }
 
   app_settings = {

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -158,6 +158,7 @@ resource "azurerm_subnet" "default_subnet" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.1.0/24"]
   service_endpoints    = ["Microsoft.Storage"]
+  depends_on           = [azurerm_virtual_network.this]
 
   delegation {
     name = "functionapp_delegation"

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -354,7 +354,7 @@ resource "azurerm_service_plan" "timerstartpipelineapp" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   os_type             = "Windows"
-  sku_name            = "Y1"
+  sku_name            = "EP1"
   depends_on = [azurerm_resource_group.rg]
 }
 
@@ -366,7 +366,7 @@ resource "azurerm_application_insights" "timerstartpipelineapp" {
   depends_on = [azurerm_resource_group.rg]
 }
 
-resource "azurerm_windows_function_app" "timerstartpipelineapp" {
+resource "azurerm_linux_function_app" "timerstartpipelineapp" {
   name                = "TimerStartPipelineFunction-${var.prefix}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
@@ -386,9 +386,12 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
     ]
   }
 
-  site_config {}
+  site_config {
+    net_framework_version = "v6.0"
+  }
 
   app_settings = {
+    FUNCTIONS_WORKER_RUNTIME = "dotnet"
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.timerstartpipelineapp.instrumentation_key
     serviceBusNameSpace=azurerm_servicebus_namespace.this.name
     adxConnectionString=azurerm_kusto_cluster.this.uri

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -354,7 +354,7 @@ resource "azurerm_service_plan" "timerstartpipelineapp" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   os_type             = "Windows"
-  sku_name            = "EP1"
+  sku_name            = "B1"
   depends_on = [azurerm_resource_group.rg]
 }
 
@@ -481,7 +481,7 @@ resource "azurerm_service_plan" "adxingestionapp" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   os_type             = "Windows"
-  sku_name            = "EP1"
+  sku_name            = "B1"
   depends_on = [azurerm_resource_group.rg]
 }
 

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -386,8 +386,7 @@ resource "azurerm_windows_function_app" "timerstartpipelineapp" {
     ]
   }
 
-  site_config {
-  }
+  site_config {}
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME = "dotnet"

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -366,7 +366,7 @@ resource "azurerm_application_insights" "timerstartpipelineapp" {
   depends_on = [azurerm_resource_group.rg]
 }
 
-resource "azurerm_linux_function_app" "timerstartpipelineapp" {
+resource "azurerm_windows_function_app" "timerstartpipelineapp" {
   name                = "TimerStartPipelineFunction-${var.prefix}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -481,7 +481,7 @@ resource "azurerm_service_plan" "adxingestionapp" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   os_type             = "Windows"
-  sku_name            = "Y1"
+  sku_name            = "EP1"
   depends_on = [azurerm_resource_group.rg]
 }
 
@@ -513,9 +513,12 @@ resource "azurerm_windows_function_app" "adxingestionapp" {
     ]
   }
 
-  site_config {}
+  site_config {
+    always_on = true
+  }
   
   app_settings = {
+    FUNCTIONS_WORKER_RUNTIME = "dotnet"
     APPINSIGHTS_INSTRUMENTATIONKEY=azurerm_application_insights.adxingestionapp.instrumentation_key
     ServiceBusMSIConnection=local.serviceBusMSIString
     ServiceBusConnection__fullyQualifiedNamespace="${azurerm_servicebus_namespace.this.name}.servicebus.windows.net"

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -330,7 +330,7 @@ resource "azurerm_storage_account_network_rules" "this" {
 # Update shared access key setting after applying network rules
 resource "null_resource" "update_shared_access_key" {
   provisioner "local-exec" {
-    command = "az storage account update --name ${azurerm_storage_account.this.name} --resource-group ${azurerm_storage_account.this.resource_group_name} --set sharedAccessKeyEnabled=false"
+    command = "az storage account update --name ${azurerm_storage_account.this.name} --resource-group ${azurerm_storage_account.this.resource_group_name} --allow-shared-key-access false"
   }
   depends_on = [azurerm_storage_account_network_rules.this]
 }


### PR DESCRIPTION
## Purpose
* because of the ongoing blocker and known gap #25 (
https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreegaps
#25), the OSS need to be upgraded to App Service Plan to support MSI

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
* Upgraded both function apps to app service plan for
* Disabled local auth for both storage account and service bus
* Added network rules in storage account to grant trusted services accessibility

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* follow README
* Don't forget navigating to the created app registration of this deployment and make sure to add Service Tree info to Branding and Properties and an additional owner to the registration